### PR TITLE
Add admin management pages

### DIFF
--- a/admin/categories.php
+++ b/admin/categories.php
@@ -1,0 +1,89 @@
+<?php
+session_start();
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: ../auth/login.php');
+    exit;
+}
+
+if ($_SESSION['role'] !== 'admin') {
+    header('Location: ../index.php');
+    exit;
+}
+
+require_once '../config/database.php';
+require_once '../includes/functions.php';
+
+$database = new Database();
+$db = $database->getConnection();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['name'], $_POST['prompt'])) {
+    $stmt = $db->prepare('INSERT INTO categories (name, prompt, active) VALUES (?, ?, 1)');
+    $stmt->execute([$_POST['name'], $_POST['prompt']]);
+    logActivity($db, 'add_category', $_POST['name']);
+}
+
+$stmt = $db->query('SELECT * FROM categories ORDER BY created_at DESC');
+$categories = $stmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kategorie - Administracja</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link href="../assets/css/style.css" rel="stylesheet">
+</head>
+<body>
+<?php include '../includes/navbar.php'; ?>
+<div class="container-fluid">
+    <div class="row">
+        <?php include '../includes/sidebar.php'; ?>
+        <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
+            <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+                <h1 class="h2"><i class="fas fa-tags"></i> Kategorie</h1>
+            </div>
+            <div class="card mb-4">
+                <div class="card-header">Dodaj kategorię</div>
+                <div class="card-body">
+                    <form method="POST">
+                        <div class="mb-3">
+                            <label class="form-label">Nazwa</label>
+                            <input type="text" name="name" class="form-control" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Prompt</label>
+                            <textarea name="prompt" class="form-control" rows="3" required></textarea>
+                        </div>
+                        <button type="submit" class="btn btn-primary">Zapisz</button>
+                    </form>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-header">Lista kategorii</div>
+                <div class="card-body table-responsive">
+                    <table class="table table-hover">
+                        <thead>
+                            <tr><th>ID</th><th>Nazwa</th><th>Aktywna</th></tr>
+                        </thead>
+                        <tbody>
+                        <?php foreach ($categories as $cat): ?>
+                            <tr>
+                                <td><?php echo $cat['id']; ?></td>
+                                <td><?php echo htmlspecialchars($cat['name']); ?></td>
+                                <td><?php echo $cat['active'] ? 'Tak' : 'Nie'; ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </main>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="../assets/js/app.js"></script>
+</body>
+</html>

--- a/admin/config.php
+++ b/admin/config.php
@@ -1,0 +1,80 @@
+<?php
+session_start();
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: ../auth/login.php');
+    exit;
+}
+
+if ($_SESSION['role'] !== 'admin') {
+    header('Location: ../index.php');
+    exit;
+}
+
+require_once '../config/database.php';
+require_once '../includes/functions.php';
+
+$database = new Database();
+$db = $database->getConnection();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['config']) && is_array($_POST['config'])) {
+    foreach ($_POST['config'] as $key => $value) {
+        $stmt = $db->prepare('UPDATE system_config SET config_value = ? WHERE config_key = ?');
+        $stmt->execute([$value, $key]);
+    }
+    logActivity($db, 'update_config');
+}
+
+$stmt = $db->query('SELECT config_key, config_value FROM system_config ORDER BY config_key');
+$config = $stmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Konfiguracja - Administracja</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link href="../assets/css/style.css" rel="stylesheet">
+</head>
+<body>
+<?php include '../includes/navbar.php'; ?>
+<div class="container-fluid">
+    <div class="row">
+        <?php include '../includes/sidebar.php'; ?>
+        <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
+            <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+                <h1 class="h2"><i class="fas fa-cog"></i> Konfiguracja</h1>
+            </div>
+            <div class="card">
+                <div class="card-body">
+                    <form method="POST">
+                        <div class="table-responsive">
+                            <table class="table table-bordered">
+                                <thead>
+                                    <tr><th>Klucz</th><th>Wartość</th></tr>
+                                </thead>
+                                <tbody>
+                                <?php foreach ($config as $row): ?>
+                                    <tr>
+                                        <td><?php echo htmlspecialchars($row['config_key']); ?></td>
+                                        <td>
+                                            <input type="text" name="config[<?php echo htmlspecialchars($row['config_key']); ?>]" value="<?php echo htmlspecialchars($row['config_value']); ?>" class="form-control">
+                                        </td>
+                                    </tr>
+                                <?php endforeach; ?>
+                                </tbody>
+                            </table>
+                        </div>
+                        <button type="submit" class="btn btn-primary">Zapisz</button>
+                    </form>
+                </div>
+            </div>
+        </main>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="../assets/js/app.js"></script>
+</body>
+</html>

--- a/admin/logs.php
+++ b/admin/logs.php
@@ -1,0 +1,67 @@
+<?php
+session_start();
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: ../auth/login.php');
+    exit;
+}
+
+if ($_SESSION['role'] !== 'admin') {
+    header('Location: ../index.php');
+    exit;
+}
+
+require_once '../config/database.php';
+require_once '../includes/functions.php';
+
+$database = new Database();
+$db = $database->getConnection();
+
+$stmt = $db->query('SELECT * FROM fetch_logs ORDER BY created_at DESC LIMIT 50');
+$logs = $stmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Logi - Administracja</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link href="../assets/css/style.css" rel="stylesheet">
+</head>
+<body>
+<?php include '../includes/navbar.php'; ?>
+<div class="container-fluid">
+    <div class="row">
+        <?php include '../includes/sidebar.php'; ?>
+        <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
+            <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+                <h1 class="h2"><i class="fas fa-file-alt"></i> Logi</h1>
+            </div>
+            <div class="card">
+                <div class="card-body table-responsive">
+                    <table class="table table-hover">
+                        <thead>
+                            <tr><th>Data</th><th>Liczba domen</th><th>Status</th><th>Komunikat</th></tr>
+                        </thead>
+                        <tbody>
+                        <?php foreach ($logs as $log): ?>
+                            <tr>
+                                <td><?php echo htmlspecialchars($log['fetch_date']); ?></td>
+                                <td><?php echo $log['domains_count']; ?></td>
+                                <td><?php echo $log['status']; ?></td>
+                                <td><?php echo htmlspecialchars($log['error_message']); ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </main>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="../assets/js/app.js"></script>
+</body>
+</html>

--- a/admin/users.php
+++ b/admin/users.php
@@ -1,0 +1,102 @@
+<?php
+session_start();
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: ../auth/login.php');
+    exit;
+}
+
+if ($_SESSION['role'] !== 'admin') {
+    header('Location: ../index.php');
+    exit;
+}
+
+require_once '../config/database.php';
+require_once '../includes/functions.php';
+
+$database = new Database();
+$db = $database->getConnection();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['username'], $_POST['email'], $_POST['password'])) {
+    $passwordHash = password_hash($_POST['password'], PASSWORD_DEFAULT);
+    $stmt = $db->prepare('INSERT INTO users (username, email, password, role) VALUES (?, ?, ?, ?)');
+    $stmt->execute([$_POST['username'], $_POST['email'], $passwordHash, $_POST['role'] ?? 'user']);
+    logActivity($db, 'add_user', $_POST['username']);
+}
+
+$stmt = $db->query('SELECT id, username, email, role, created_at FROM users ORDER BY created_at DESC');
+$users = $stmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Użytkownicy - Administracja</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link href="../assets/css/style.css" rel="stylesheet">
+</head>
+<body>
+<?php include '../includes/navbar.php'; ?>
+<div class="container-fluid">
+    <div class="row">
+        <?php include '../includes/sidebar.php'; ?>
+        <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
+            <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+                <h1 class="h2"><i class="fas fa-users"></i> Użytkownicy</h1>
+            </div>
+            <div class="card mb-4">
+                <div class="card-header">Dodaj użytkownika</div>
+                <div class="card-body">
+                    <form method="POST">
+                        <div class="mb-3">
+                            <label class="form-label">Nazwa użytkownika</label>
+                            <input type="text" name="username" class="form-control" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Email</label>
+                            <input type="email" name="email" class="form-control" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Hasło</label>
+                            <input type="password" name="password" class="form-control" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Rola</label>
+                            <select name="role" class="form-select">
+                                <option value="user">Użytkownik</option>
+                                <option value="admin">Administrator</option>
+                            </select>
+                        </div>
+                        <button type="submit" class="btn btn-primary">Zapisz</button>
+                    </form>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-header">Lista użytkowników</div>
+                <div class="card-body table-responsive">
+                    <table class="table table-hover">
+                        <thead>
+                            <tr><th>ID</th><th>Nazwa</th><th>Email</th><th>Rola</th></tr>
+                        </thead>
+                        <tbody>
+                        <?php foreach ($users as $user): ?>
+                            <tr>
+                                <td><?php echo $user['id']; ?></td>
+                                <td><?php echo htmlspecialchars($user['username']); ?></td>
+                                <td><?php echo htmlspecialchars($user['email']); ?></td>
+                                <td><?php echo $user['role']; ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </main>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="../assets/js/app.js"></script>
+</body>
+</html>

--- a/config/database.php
+++ b/config/database.php
@@ -7,7 +7,7 @@ class Database {
     private $conn;
 
     public function __construct() {
-        $config = include 'config.php';
+        $config = include __DIR__ . '/config.php';
         $this->host = $config['db_host'];
         $this->db_name = $config['db_name'];
         $this->username = $config['db_username'];

--- a/cron/cleanup.php
+++ b/cron/cleanup.php
@@ -1,4 +1,3 @@
-#!/usr/bin/php
 <?php
 // Cron job do czyszczenia starych danych
 require_once dirname(__DIR__) . '/config/database.php';

--- a/cron/fetch_domains.php
+++ b/cron/fetch_domains.php
@@ -1,4 +1,3 @@
-#!/usr/bin/php
 <?php
 // Cron job do pobierania domen
 require_once dirname(__DIR__) . '/config/database.php';

--- a/cron/send_reminders.php
+++ b/cron/send_reminders.php
@@ -1,4 +1,3 @@
-#!/usr/bin/php
 <?php
 // Cron job do wysyłania przypomnień
 require_once dirname(__DIR__) . '/config/database.php';

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -60,17 +60,17 @@ function getUpcomingRegistrations($db, $userId, $days = 7) {
 }
 
 function sendEmail($to, $subject, $body, $isHtml = true) {
-    $config = include 'config/config.php';
+    $config = include __DIR__ . '/../config/config.php';
     
     // Sprawdź czy PHPMailer jest zainstalowany
-    if (!file_exists('vendor/phpmailer/phpmailer/src/PHPMailer.php')) {
+    if (!file_exists(__DIR__ . '/../vendor/phpmailer/phpmailer/src/PHPMailer.php')) {
         error_log("PHPMailer not installed. Run: composer install");
         return false;
     }
-    
-    require_once 'vendor/phpmailer/phpmailer/src/PHPMailer.php';
-    require_once 'vendor/phpmailer/phpmailer/src/SMTP.php';
-    require_once 'vendor/phpmailer/phpmailer/src/Exception.php';
+
+    require_once __DIR__ . '/../vendor/phpmailer/phpmailer/src/PHPMailer.php';
+    require_once __DIR__ . '/../vendor/phpmailer/phpmailer/src/SMTP.php';
+    require_once __DIR__ . '/../vendor/phpmailer/phpmailer/src/Exception.php';
     
     $mail = new PHPMailer\PHPMailer\PHPMailer(true);
     
@@ -100,7 +100,7 @@ function sendEmail($to, $subject, $body, $isHtml = true) {
 }
 
 function callGeminiAPI($prompt, $domains) {
-    $config = include 'config/config.php';
+    $config = include __DIR__ . '/../config/config.php';
     
     $data = [
         'contents' => [


### PR DESCRIPTION
## Summary
- add `admin/` section with stub pages for categories, users, configuration and logs
- each new page checks for admin role and displays simple management forms
- fix cron scripts to load config correctly and remove stray shebang output
- ensure functions use absolute paths when included by cron

## Testing
- `php -l admin/categories.php`
- `php -l admin/users.php`
- `php -l admin/config.php`
- `php -l admin/logs.php`
- `php -l cron/fetch_domains.php`
- `php -l cron/send_reminders.php`
- `php -l cron/cleanup.php`
- `php -l includes/functions.php`
- `php -l config/database.php`
- `composer install` *(fails: CONNECT tunnel failed)*


------
https://chatgpt.com/codex/tasks/task_e_6879d9ffccdc8333bd9ff4ba3e30ccc5