### PR TITLE
Fix navigation links to use root paths

### DIFF
--- a/includes/navbar.php
+++ b/includes/navbar.php
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
     <div class="container-fluid">
-        <a class="navbar-brand" href="index.php">
+        <a class="navbar-brand" href="/index.php">
             <i class="fas fa-globe"></i> Domain Monitor
         </a>
         
@@ -11,17 +11,17 @@
         <div class="collapse navbar-collapse" id="navbarNav">
             <ul class="navbar-nav me-auto">
                 <li class="nav-item">
-                    <a class="nav-link" href="index.php">
+                    <a class="nav-link" href="/index.php">
                         <i class="fas fa-tachometer-alt"></i> Dashboard
                     </a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="domains/">
+                    <a class="nav-link" href="/domains/">
                         <i class="fas fa-list"></i> Domeny
                     </a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="favorites.php">
+                    <a class="nav-link" href="/favorites.php">
                         <i class="fas fa-heart"></i> Ulubione
                     </a>
                 </li>
@@ -31,10 +31,10 @@
                         <i class="fas fa-cog"></i> Administracja
                     </a>
                     <ul class="dropdown-menu">
-                        <li><a class="dropdown-item" href="admin/categories.php">Kategorie</a></li>
-                        <li><a class="dropdown-item" href="admin/users.php">Użytkownicy</a></li>
-                        <li><a class="dropdown-item" href="admin/config.php">Konfiguracja</a></li>
-                        <li><a class="dropdown-item" href="admin/logs.php">Logi</a></li>
+                        <li><a class="dropdown-item" href="/admin/categories.php">Kategorie</a></li>
+                        <li><a class="dropdown-item" href="/admin/users.php">Użytkownicy</a></li>
+                        <li><a class="dropdown-item" href="/admin/config.php">Konfiguracja</a></li>
+                        <li><a class="dropdown-item" href="/admin/logs.php">Logi</a></li>
                     </ul>
                 </li>
                 <?php endif; ?>
@@ -46,9 +46,9 @@
                         <i class="fas fa-user"></i> <?php echo htmlspecialchars($_SESSION['username']); ?>
                     </a>
                     <ul class="dropdown-menu">
-                        <li><a class="dropdown-item" href="profile.php">Profil</a></li>
+                        <li><a class="dropdown-item" href="/profile.php">Profil</a></li>
                         <li><hr class="dropdown-divider"></li>
-                        <li><a class="dropdown-item" href="auth/logout.php">Wyloguj</a></li>
+                        <li><a class="dropdown-item" href="/auth/logout.php">Wyloguj</a></li>
                     </ul>
                 </li>
             </ul>

--- a/includes/sidebar.php
+++ b/includes/sidebar.php
@@ -2,27 +2,27 @@
     <div class="position-sticky pt-3">
         <ul class="nav flex-column">
             <li class="nav-item">
-                <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) === 'index.php' ? 'active' : ''; ?>" href="index.php">
+                <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) === 'index.php' ? 'active' : ''; ?>" href="/index.php">
                     <i class="fas fa-tachometer-alt"></i> Dashboard
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link <?php echo strpos($_SERVER['REQUEST_URI'], '/domains/') !== false ? 'active' : ''; ?>" href="domains/">
+                <a class="nav-link <?php echo strpos($_SERVER['REQUEST_URI'], '/domains/') !== false ? 'active' : ''; ?>" href="/domains/">
                     <i class="fas fa-list"></i> Wszystkie domeny
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) === 'favorites.php' ? 'active' : ''; ?>" href="favorites.php">
+                <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) === 'favorites.php' ? 'active' : ''; ?>" href="/favorites.php">
                     <i class="fas fa-heart"></i> Ulubione
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="domains/?filter=today">
+                <a class="nav-link" href="/domains/?filter=today">
                     <i class="fas fa-calendar-day"></i> Dzisiejsze
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="domains/?filter=interesting">
+                <a class="nav-link" href="/domains/?filter=interesting">
                     <i class="fas fa-star"></i> Interesujące
                 </a>
             </li>
@@ -43,7 +43,7 @@
             foreach ($categories as $category):
             ?>
             <li class="nav-item">
-                <a class="nav-link" href="domains/?category=<?php echo $category['id']; ?>">
+                <a class="nav-link" href="/domains/?category=<?php echo $category['id']; ?>">
                     <i class="fas fa-tag"></i> <?php echo htmlspecialchars($category['name']); ?>
                 </a>
             </li>
@@ -56,22 +56,22 @@
         </h6>
         <ul class="nav flex-column mb-2">
             <li class="nav-item">
-                <a class="nav-link" href="admin/categories.php">
+                <a class="nav-link" href="/admin/categories.php">
                     <i class="fas fa-tags"></i> Kategorie
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="admin/users.php">
+                <a class="nav-link" href="/admin/users.php">
                     <i class="fas fa-users"></i> Użytkownicy
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="admin/config.php">
+                <a class="nav-link" href="/admin/config.php">
                     <i class="fas fa-cog"></i> Konfiguracja
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="admin/logs.php">
+                <a class="nav-link" href="/admin/logs.php">
                     <i class="fas fa-file-alt"></i> Logi
                 </a>
             </li>


### PR DESCRIPTION
## Summary
- switch navbar links to root-relative URLs
- switch sidebar links to root-relative URLs

## Testing
- `composer validate`
- `php -l includes/navbar.php includes/sidebar.php`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6879f7d94148833395edc2169c17278a