### PR TITLE
Add activity logs table

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,26 @@ System obsługuje wysyłanie emaili przez SMTP. Skonfiguruj:
 - Sesje zabezpieczone
 - Logi aktywności
 
+## Aktualizacja bazy danych
+
+Po aktualizacji projektu do najnowszej wersji należy dodać tabelę `activity_logs`.
+Uruchom zapytania SQL z katalogu `supabase/migrations/` lub wykonaj poniższe
+polecenie w swojej bazie danych:
+
+```sql
+CREATE TABLE IF NOT EXISTS activity_logs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    action VARCHAR(100) NOT NULL,
+    details TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+```
+
+Jeśli korzystasz z wcześniejszej instalacji, wystarczy uruchomić ten skrypt lub
+zaimportować zaktualizowane migracje.
+
 ## Wsparcie
 
 W przypadku problemów:

--- a/install.php
+++ b/install.php
@@ -124,6 +124,15 @@
                                         FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
                                         FOREIGN KEY (domain_id) REFERENCES domains(id) ON DELETE CASCADE
                                     )",
+
+                                    "CREATE TABLE IF NOT EXISTS activity_logs (
+                                        id INT AUTO_INCREMENT PRIMARY KEY,
+                                        user_id INT NOT NULL,
+                                        action VARCHAR(100) NOT NULL,
+                                        details TEXT,
+                                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                                        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+                                    )",
                                     
                                     "INSERT IGNORE INTO categories (name, prompt) VALUES 
                                     ('Moda', 'Przeanalizuj przesłaną listę domen, czy na tej liście znajdują się domeny, które pasują pod stronę o tematyce: moda. Wynik przedstaw w tabeli podając domenę oraz jej krótki opis, dlaczego jest interesująca. Tabela powinna być w formacie HTML.'),

--- a/supabase/migrations/20250717212801_royal_fountain.sql
+++ b/supabase/migrations/20250717212801_royal_fountain.sql
@@ -83,6 +83,16 @@ CREATE TABLE IF NOT EXISTS notifications (
     FOREIGN KEY (domain_id) REFERENCES domains(id) ON DELETE CASCADE
 );
 
+-- Tabela logów aktywności
+CREATE TABLE IF NOT EXISTS activity_logs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    action VARCHAR(100) NOT NULL,
+    details TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
 -- Wstaw domyślne kategorie
 INSERT INTO categories (name, prompt) VALUES 
 ('Moda', 'Przeanalizuj przesłaną listę domen, czy na tej liście znajdują się domeny, które pasują pod stronę o tematyce: moda. Wynik przedstaw w tabeli podając domenę oraz jej krótki opis, dlaczego jest interesująca. Tabela powinna być w formacie HTML.'),

--- a/supabase/migrations/20250717214316_proud_frost.sql
+++ b/supabase/migrations/20250717214316_proud_frost.sql
@@ -83,6 +83,16 @@ CREATE TABLE IF NOT EXISTS notifications (
     FOREIGN KEY (domain_id) REFERENCES domains(id) ON DELETE CASCADE
 );
 
+-- Tabela logów aktywności
+CREATE TABLE IF NOT EXISTS activity_logs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    action VARCHAR(100) NOT NULL,
+    details TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
 -- Wstaw domyślne kategorie
 INSERT INTO categories (name, prompt) VALUES 
 ('Moda', 'Przeanalizuj przesłaną listę domen, czy na tej liście znajdują się domeny, które pasują pod stronę o tematyce: moda. Wynik przedstaw w tabeli podając domenę oraz jej krótki opis, dlaczego jest interesująca. Tabela powinna być w formacie HTML.'),


### PR DESCRIPTION
## Summary
- extend install.php with activity_logs table
- add activity_logs table to migration SQL
- document migration step in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6879f9da7fc48333ab6fae67bf040273