### PR TITLE
Fix ONLY_FULL_GROUP_BY issues

### DIFF
--- a/domains/index.php
+++ b/domains/index.php
@@ -49,16 +49,26 @@ $whereClause = !empty($whereConditions) ? 'WHERE ' . implode(' AND ', $whereCond
 
 // Pobierz domeny
 $sql = "
-    SELECT DISTINCT d.*, 
-           GROUP_CONCAT(DISTINCT c.name) as categories,
-           GROUP_CONCAT(DISTINCT da.description SEPARATOR ' | ') as descriptions,
-           CASE WHEN fd.id IS NOT NULL THEN 1 ELSE 0 END as is_favorite
+    SELECT
+        d.id,
+        d.domain_name,
+        d.fetch_date,
+        d.registration_available_date,
+        d.created_at,
+        GROUP_CONCAT(DISTINCT c.name) AS categories,
+        GROUP_CONCAT(DISTINCT da.description SEPARATOR ' | ') AS descriptions,
+        CASE WHEN MAX(fd.id) IS NOT NULL THEN 1 ELSE 0 END AS is_favorite
     FROM domains d
     LEFT JOIN domain_analysis da ON d.id = da.domain_id
     LEFT JOIN categories c ON da.category_id = c.id
     LEFT JOIN favorite_domains fd ON d.id = fd.domain_id AND fd.user_id = ?
     $whereClause
-    GROUP BY d.id
+    GROUP BY
+        d.id,
+        d.domain_name,
+        d.fetch_date,
+        d.registration_available_date,
+        d.created_at
     ORDER BY d.created_at DESC
     LIMIT $perPage OFFSET $offset
 ";

--- a/favorites.php
+++ b/favorites.php
@@ -15,7 +15,26 @@ try {
 } catch (Exception $e) {
     die('Błąd połączenia z bazą danych: ' . $e->getMessage());
 }
-$stmt = $db->prepare("SELECT d.*, GROUP_CONCAT(DISTINCT c.name) AS categories, GROUP_CONCAT(DISTINCT da.description SEPARATOR " | ") AS descriptions FROM favorite_domains fd JOIN domains d ON fd.domain_id = d.id LEFT JOIN domain_analysis da ON d.id = da.domain_id LEFT JOIN categories c ON da.category_id = c.id WHERE fd.user_id = ? GROUP BY d.id ORDER BY fd.created_at DESC");
+$stmt = $db->prepare("SELECT
+        d.id,
+        d.domain_name,
+        d.fetch_date,
+        d.registration_available_date,
+        d.created_at,
+        GROUP_CONCAT(DISTINCT c.name) AS categories,
+        GROUP_CONCAT(DISTINCT da.description SEPARATOR ' | ') AS descriptions
+     FROM favorite_domains fd
+     JOIN domains d ON fd.domain_id = d.id
+     LEFT JOIN domain_analysis da ON d.id = da.domain_id
+     LEFT JOIN categories c ON da.category_id = c.id
+     WHERE fd.user_id = ?
+     GROUP BY
+        d.id,
+        d.domain_name,
+        d.fetch_date,
+        d.registration_available_date,
+        d.created_at
+     ORDER BY fd.created_at DESC");
 
 $stmt->execute([$_SESSION['user_id']]);
 $domains = $stmt->fetchAll(PDO::FETCH_ASSOC);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -30,16 +30,26 @@ function getDashboardStats($db) {
 
 function getRecentDomains($db, $limit = 10) {
     $limit = (int) $limit;
-    $stmt = $db->prepare("
-        SELECT d.*,
-               GROUP_CONCAT(c.name) as categories
-        FROM domains d
-        LEFT JOIN domain_analysis da ON d.id = da.domain_id AND da.is_interesting = 1
-        LEFT JOIN categories c ON da.category_id = c.id
-        GROUP BY d.id
-        ORDER BY d.created_at DESC
-        LIMIT $limit
-    ");
+    $stmt = $db->prepare(
+        "SELECT
+            d.id,
+            d.domain_name,
+            d.fetch_date,
+            d.registration_available_date,
+            d.created_at,
+            GROUP_CONCAT(c.name) AS categories
+         FROM domains d
+         LEFT JOIN domain_analysis da ON d.id = da.domain_id AND da.is_interesting = 1
+         LEFT JOIN categories c ON da.category_id = c.id
+         GROUP BY
+            d.id,
+            d.domain_name,
+            d.fetch_date,
+            d.registration_available_date,
+            d.created_at
+         ORDER BY d.created_at DESC
+         LIMIT $limit"
+    );
     $stmt->execute();
     return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }


### PR DESCRIPTION
## Summary
- select explicit columns for domains listing
- match GROUP BY to all selected columns
- update favorites and dashboard helpers

## Testing
- `php -l domains/index.php favorites.php includes/functions.php`

------
https://chatgpt.com/codex/tasks/task_e_6879fb8987bc833386801f6778e3bff0