### PR TITLE
Use configured base URL in navigation

### DIFF
--- a/includes/navbar.php
+++ b/includes/navbar.php
@@ -1,6 +1,10 @@
+<?php
+$config = include __DIR__ . '/../config/config.php';
+$baseUrl = rtrim($config['site_url'], '/');
+?>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
     <div class="container-fluid">
-        <a class="navbar-brand" href="/index.php">
+        <a class="navbar-brand" href="<?= $baseUrl ?>/index.php">
             <i class="fas fa-globe"></i> Domain Monitor
         </a>
         
@@ -11,17 +15,17 @@
         <div class="collapse navbar-collapse" id="navbarNav">
             <ul class="navbar-nav me-auto">
                 <li class="nav-item">
-                    <a class="nav-link" href="/index.php">
+                    <a class="nav-link" href="<?= $baseUrl ?>/index.php">
                         <i class="fas fa-tachometer-alt"></i> Dashboard
                     </a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="/domains/">
+                    <a class="nav-link" href="<?= $baseUrl ?>/domains/">
                         <i class="fas fa-list"></i> Domeny
                     </a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="/favorites.php">
+                    <a class="nav-link" href="<?= $baseUrl ?>/favorites.php">
                         <i class="fas fa-heart"></i> Ulubione
                     </a>
                 </li>
@@ -31,10 +35,10 @@
                         <i class="fas fa-cog"></i> Administracja
                     </a>
                     <ul class="dropdown-menu">
-                        <li><a class="dropdown-item" href="/admin/categories.php">Kategorie</a></li>
-                        <li><a class="dropdown-item" href="/admin/users.php">Użytkownicy</a></li>
-                        <li><a class="dropdown-item" href="/admin/config.php">Konfiguracja</a></li>
-                        <li><a class="dropdown-item" href="/admin/logs.php">Logi</a></li>
+                        <li><a class="dropdown-item" href="<?= $baseUrl ?>/admin/categories.php">Kategorie</a></li>
+                        <li><a class="dropdown-item" href="<?= $baseUrl ?>/admin/users.php">Użytkownicy</a></li>
+                        <li><a class="dropdown-item" href="<?= $baseUrl ?>/admin/config.php">Konfiguracja</a></li>
+                        <li><a class="dropdown-item" href="<?= $baseUrl ?>/admin/logs.php">Logi</a></li>
                     </ul>
                 </li>
                 <?php endif; ?>
@@ -46,9 +50,9 @@
                         <i class="fas fa-user"></i> <?php echo htmlspecialchars($_SESSION['username']); ?>
                     </a>
                     <ul class="dropdown-menu">
-                        <li><a class="dropdown-item" href="/profile.php">Profil</a></li>
+                        <li><a class="dropdown-item" href="<?= $baseUrl ?>/profile.php">Profil</a></li>
                         <li><hr class="dropdown-divider"></li>
-                        <li><a class="dropdown-item" href="/auth/logout.php">Wyloguj</a></li>
+                        <li><a class="dropdown-item" href="<?= $baseUrl ?>/auth/logout.php">Wyloguj</a></li>
                     </ul>
                 </li>
             </ul>

--- a/includes/sidebar.php
+++ b/includes/sidebar.php
@@ -1,28 +1,32 @@
+<?php
+$config = include __DIR__ . '/../config/config.php';
+$baseUrl = rtrim($config['site_url'], '/');
+?>
 <nav id="sidebarMenu" class="col-md-3 col-lg-2 d-md-block bg-light sidebar collapse">
     <div class="position-sticky pt-3">
         <ul class="nav flex-column">
             <li class="nav-item">
-                <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) === 'index.php' ? 'active' : ''; ?>" href="/index.php">
+                <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) === 'index.php' ? 'active' : ''; ?>" href="<?= $baseUrl ?>/index.php">
                     <i class="fas fa-tachometer-alt"></i> Dashboard
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link <?php echo strpos($_SERVER['REQUEST_URI'], '/domains/') !== false ? 'active' : ''; ?>" href="/domains/">
+                <a class="nav-link <?php echo strpos($_SERVER['REQUEST_URI'], '/domains/') !== false ? 'active' : ''; ?>" href="<?= $baseUrl ?>/domains/">
                     <i class="fas fa-list"></i> Wszystkie domeny
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) === 'favorites.php' ? 'active' : ''; ?>" href="/favorites.php">
+                <a class="nav-link <?php echo basename($_SERVER['PHP_SELF']) === 'favorites.php' ? 'active' : ''; ?>" href="<?= $baseUrl ?>/favorites.php">
                     <i class="fas fa-heart"></i> Ulubione
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="/domains/?filter=today">
+                <a class="nav-link" href="<?= $baseUrl ?>/domains/?filter=today">
                     <i class="fas fa-calendar-day"></i> Dzisiejsze
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="/domains/?filter=interesting">
+                <a class="nav-link" href="<?= $baseUrl ?>/domains/?filter=interesting">
                     <i class="fas fa-star"></i> Interesujące
                 </a>
             </li>
@@ -43,7 +47,7 @@
             foreach ($categories as $category):
             ?>
             <li class="nav-item">
-                <a class="nav-link" href="/domains/?category=<?php echo $category['id']; ?>">
+                <a class="nav-link" href="<?= $baseUrl ?>/domains/?category=<?php echo $category['id']; ?>">
                     <i class="fas fa-tag"></i> <?php echo htmlspecialchars($category['name']); ?>
                 </a>
             </li>
@@ -56,22 +60,22 @@
         </h6>
         <ul class="nav flex-column mb-2">
             <li class="nav-item">
-                <a class="nav-link" href="/admin/categories.php">
+                <a class="nav-link" href="<?= $baseUrl ?>/admin/categories.php">
                     <i class="fas fa-tags"></i> Kategorie
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="/admin/users.php">
+                <a class="nav-link" href="<?= $baseUrl ?>/admin/users.php">
                     <i class="fas fa-users"></i> Użytkownicy
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="/admin/config.php">
+                <a class="nav-link" href="<?= $baseUrl ?>/admin/config.php">
                     <i class="fas fa-cog"></i> Konfiguracja
                 </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="/admin/logs.php">
+                <a class="nav-link" href="<?= $baseUrl ?>/admin/logs.php">
                     <i class="fas fa-file-alt"></i> Logi
                 </a>
             </li>


### PR DESCRIPTION
## Summary
- load the main config in `navbar.php` and `sidebar.php`
- prefix navigation links with the configured `site_url`

## Testing
- `composer validate --no-check-publish`
- `composer install --no-interaction` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6879ffccd10483339bc3d34f0cbd7cd0