### PR TITLE
Integrate SEMSTORM stats in domain view

### DIFF
--- a/config/config.example.php
+++ b/config/config.example.php
@@ -13,6 +13,10 @@ return [
     'email_username' => 'your_email@gmail.com',
     'email_password' => 'your_app_password',
     'email_from_name' => 'Domain Monitor',
+
+    // SEMSTORM API credentials
+    'semstorm_client_id' => 'your_semstorm_client_id',
+    'semstorm_client_secret' => 'your_semstorm_client_secret',
     
     'site_url' => 'https://yourdomain.com',
     'site_name' => 'Domain Monitor',

--- a/domains/view.php
+++ b/domains/view.php
@@ -58,6 +58,8 @@ try {
 $regDate = strtotime($domain['registration_available_date']);
 $today = time();
 $daysLeft = ceil(($regDate - $today) / (60 * 60 * 24));
+
+$semstormStats = getSemstormDomainVisibility($domain['domain_name']);
 ?>
 
 <!DOCTYPE html>
@@ -160,6 +162,42 @@ $daysLeft = ceil(($regDate - $today) / (60 * 60 * 24));
                         </div>
                     </div>
                 </div>
+
+                <!-- Widoczność SEMSTORM -->
+                <?php if ($semstormStats): ?>
+                <div class="card mb-4">
+                    <div class="card-header">
+                        <h5 class="mb-0"><i class="fas fa-chart-line"></i> Widoczność SEMSTORM</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col-md-6">
+                                <h6>Aktualne dane<?php if (!empty($semstormStats['current']['date'])) echo ' (' . DateTime::createFromFormat('Ymd', $semstormStats['current']['date'])->format('d.m.Y') . ')'; ?></h6>
+                                <ul class="list-unstyled">
+                                    <li>TOP3: <?php echo number_format($semstormStats['current']['top3']); ?></li>
+                                    <li>TOP10: <?php echo number_format($semstormStats['current']['top10']); ?></li>
+                                    <li>TOP20: <?php echo number_format($semstormStats['current']['top20']); ?></li>
+                                    <li>Ruch: <?php echo number_format($semstormStats['current']['traffic']); ?></li>
+                                </ul>
+                            </div>
+                            <div class="col-md-6">
+                                <h6>Maksymalna widoczność</h6>
+                                <ul class="list-unstyled">
+                                    <li>TOP3: <?php echo number_format($semstormStats['max']['top3']); ?><?php if ($semstormStats['max']['date_top3']) echo ' (' . DateTime::createFromFormat('Ymd', $semstormStats['max']['date_top3'])->format('d.m.Y') . ')'; ?></li>
+                                    <li>TOP10: <?php echo number_format($semstormStats['max']['top10']); ?><?php if ($semstormStats['max']['date_top10']) echo ' (' . DateTime::createFromFormat('Ymd', $semstormStats['max']['date_top10'])->format('d.m.Y') . ')'; ?></li>
+                                    <li>TOP20: <?php echo number_format($semstormStats['max']['top20']); ?><?php if ($semstormStats['max']['date_top20']) echo ' (' . DateTime::createFromFormat('Ymd', $semstormStats['max']['date_top20'])->format('d.m.Y') . ')'; ?></li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <?php else: ?>
+                <div class="card mb-4">
+                    <div class="card-body text-center">
+                        <p class="text-muted mb-0">Brak danych z SEMSTORM.</p>
+                    </div>
+                </div>
+                <?php endif; ?>
 
                 <!-- Analiza AI -->
                 <?php if (!empty($analyses)): ?>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -179,6 +179,126 @@ function parseDomainAnalysis($htmlResponse) {
     return $domains;
 }
 
+function getSemstormAccessToken() {
+    static $cache = null;
+    if ($cache && $cache['expire'] > time()) {
+        return $cache['token'];
+    }
+
+    $config = include __DIR__ . '/../config/config.php';
+    if (empty($config['semstorm_client_id']) || empty($config['semstorm_client_secret'])) {
+        return false;
+    }
+
+    $payload = ['grant_type' => 'client_credentials'];
+    $auth = base64_encode($config['semstorm_client_id'] . ':' . $config['semstorm_client_secret']);
+
+    $ch = curl_init('https://api.semstorm.com/authorization/token');
+    curl_setopt($ch, CURLOPT_POST, 1);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'Authorization: Basic ' . $auth,
+        'Content-Type: application/json'
+    ]);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($payload));
+
+    $response = curl_exec($ch);
+    curl_close($ch);
+
+    $data = json_decode($response, true);
+    if (!empty($data['access_token'])) {
+        $cache = [
+            'token' => $data['access_token'],
+            'expire' => time() + ($data['expires_in'] ?? 3600)
+        ];
+        return $cache['token'];
+    }
+
+    return false;
+}
+
+function getSemstormDomainVisibility($domain) {
+    $token = getSemstormAccessToken();
+    if (!$token) {
+        return null;
+    }
+
+    $payload = [
+        'domains' => [$domain],
+        'dates' => ['20120101', date('Ymd')],
+        'version' => 1
+    ];
+
+    $ch = curl_init('https://api.semstorm.com/semstorm/v4/explorer/domain-stats');
+    curl_setopt($ch, CURLOPT_POST, 1);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'Authorization: Bearer ' . $token,
+        'Content-Type: application/json'
+    ]);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($payload));
+
+    $response = curl_exec($ch);
+    curl_close($ch);
+
+    $data = json_decode($response, true);
+    if (empty($data['results'][$domain])) {
+        return null;
+    }
+
+    $rows = $data['results'][$domain];
+    ksort($rows);
+
+    $maxTop3 = $maxTop10 = $maxTop20 = 0;
+    $maxDateTop3 = $maxDateTop10 = $maxDateTop20 = null;
+    $currentRow = null;
+    $currentDate = null;
+
+    foreach ($rows as $date => $row) {
+        $kdata = $row['keywords_data'] ?? [];
+        if (isset($kdata['top3']) && $kdata['top3'] > $maxTop3) {
+            $maxTop3 = $kdata['top3'];
+            $maxDateTop3 = $date;
+        }
+        if (isset($kdata['top10']) && $kdata['top10'] > $maxTop10) {
+            $maxTop10 = $kdata['top10'];
+            $maxDateTop10 = $date;
+        }
+        if (isset($kdata['top20']) && $kdata['top20'] > $maxTop20) {
+            $maxTop20 = $kdata['top20'];
+            $maxDateTop20 = $date;
+        }
+
+        if (!$currentDate || $date > $currentDate) {
+            $currentDate = $date;
+            $currentRow = $row;
+        }
+    }
+
+    $current = null;
+    if ($currentRow) {
+        $current = [
+            'date' => $currentDate,
+            'top3' => $currentRow['keywords_data']['top3'] ?? 0,
+            'top10' => $currentRow['keywords_data']['top10'] ?? 0,
+            'top20' => $currentRow['keywords_data']['top20'] ?? 0,
+            'traffic' => $currentRow['traffic'] ?? 0,
+        ];
+    }
+
+    return [
+        'max' => [
+            'top3' => $maxTop3,
+            'date_top3' => $maxDateTop3,
+            'top10' => $maxTop10,
+            'date_top10' => $maxDateTop10,
+            'top20' => $maxTop20,
+            'date_top20' => $maxDateTop20,
+        ],
+        'current' => $current
+    ];
+}
+
 function logActivity($db, $action, $details = '') {
     $stmt = $db->prepare("INSERT INTO activity_logs (user_id, action, details, created_at) VALUES (?, ?, ?, NOW())");
     $stmt->execute([$_SESSION['user_id'] ?? 0, $action, $details]);


### PR DESCRIPTION
## Summary
- add SEMSTORM API credentials to config example
- support fetching SEMSTORM token and domain visibility data
- display historical and current visibility on domain detail page

## Testing
- `php -l domains/view.php`
- `php -l includes/functions.php`
- `php -l config/config.example.php`


------
https://chatgpt.com/codex/tasks/task_e_687a3ae992e883338fa5d4d266a7c93f