### PR TITLE
Add DR and linking domain management

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ CREATE TABLE IF NOT EXISTS activity_logs (
 
 Jeśli korzystasz z wcześniejszej instalacji, wystarczy uruchomić ten skrypt lub
 zaimportować zaktualizowane migracje.
+Najnowsze wydanie dodaje kolumny `dr` i `linking_domains` w tabeli `domains`. Po aktualizacji pamiętaj o uruchomieniu najnowszej migracji z katalogu `supabase/migrations/`.
 
 ## Wsparcie
 

--- a/install.php
+++ b/install.php
@@ -71,6 +71,8 @@
                                         domain_name VARCHAR(255) NOT NULL,
                                         fetch_date DATE NOT NULL,
                                         registration_available_date DATE NOT NULL,
+                                        dr INT NULL,
+                                        linking_domains INT NULL,
                                         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                                         INDEX idx_domain_fetch (domain_name, fetch_date),
                                         INDEX idx_registration_date (registration_available_date)

--- a/supabase/migrations/20250718230000_add_dr_and_links.sql
+++ b/supabase/migrations/20250718230000_add_dr_and_links.sql
@@ -1,0 +1,3 @@
+ALTER TABLE domains
+    ADD COLUMN dr INT NULL,
+    ADD COLUMN linking_domains INT NULL;


### PR DESCRIPTION
## Summary
- add migration to extend `domains` table with `dr` and `linking_domains`
- update installer to create new columns
- allow saving DR and linking domain counts from favorites list
- display editing form and success message in favorites view
- document the need to run the new migration

## Testing
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_688080cb5c948333a5afb4057c41997e