### PR TITLE
Add Moz metrics refresh feature

### DIFF
--- a/ajax/refresh_moz.php
+++ b/ajax/refresh_moz.php
@@ -1,0 +1,57 @@
+<?php
+session_start();
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['user_id'])) {
+    echo json_encode(['success' => false, 'error' => 'Unauthorized']);
+    exit;
+}
+
+require_once '../config/database.php';
+require_once '../includes/moz.php';
+
+$database = new Database();
+$db = $database->getConnection();
+
+$input = json_decode(file_get_contents('php://input'), true);
+$domainId = $input['domain_id'] ?? null;
+
+if (!$domainId) {
+    echo json_encode(['success' => false, 'error' => 'Missing domain ID']);
+    exit;
+}
+
+try {
+    $stmt = $db->prepare('SELECT id, user_id, domain_name FROM domains WHERE id = ?');
+    $stmt->execute([$domainId]);
+    $domain = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$domain) {
+        echo json_encode(['success' => false, 'error' => 'Domain not found']);
+        exit;
+    }
+
+    // Check if user has access - domain must be favorite or user is admin.
+    $isAdmin = $_SESSION['role'] ?? '' === 'admin';
+    $authorized = $isAdmin;
+    if (!$authorized) {
+        $stmt = $db->prepare('SELECT 1 FROM favorite_domains WHERE user_id = ? AND domain_id = ?');
+        $stmt->execute([$_SESSION['user_id'], $domainId]);
+        $authorized = (bool) $stmt->fetchColumn();
+    }
+
+    if (!$authorized) {
+        echo json_encode(['success' => false, 'error' => 'Forbidden']);
+        exit;
+    }
+
+    updateMozMetrics($db, $domainId, $domain['domain_name']);
+
+    $stmt = $db->prepare('SELECT domain_authority, page_authority, linking_domains, linking_domains_list FROM domains WHERE id = ?');
+    $stmt->execute([$domainId]);
+    $metrics = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    echo json_encode(['success' => true, 'metrics' => $metrics]);
+} catch (Exception $e) {
+    echo json_encode(['success' => false, 'error' => $e->getMessage()]);
+}

--- a/domains/view.php
+++ b/domains/view.php
@@ -173,24 +173,29 @@ $daysLeft = ceil(($regDate - $today) / (60 * 60 * 24));
                 </div>
 
                 <div class="card mb-4">
-                    <div class="card-header">
+                    <div class="card-header d-flex justify-content-between align-items-center">
                         <h5 class="mb-0"><i class="fas fa-chart-line"></i> Statystyki linków</h5>
+                        <button id="refreshMozBtn" class="btn btn-sm btn-outline-secondary" data-domain-id="<?php echo $domain['id']; ?>">
+                            <i class="fas fa-sync-alt"></i> Odśwież
+                        </button>
                     </div>
                     <div class="card-body">
                         <div class="row mb-2">
-                            <div class="col-md-4"><strong>Domain Authority:</strong> <?php echo $domain['domain_authority'] ?? '-'; ?></div>
-                            <div class="col-md-4"><strong>Page Authority:</strong> <?php echo $domain['page_authority'] ?? '-'; ?></div>
-                            <div class="col-md-4"><strong>Linkujące domeny:</strong> <?php echo $domain['linking_domains'] ?? '-'; ?></div>
+                            <div class="col-md-4"><strong>Domain Authority:</strong> <span id="moz-da"><?php echo $domain['domain_authority'] ?? '-'; ?></span></div>
+                            <div class="col-md-4"><strong>Page Authority:</strong> <span id="moz-pa"><?php echo $domain['page_authority'] ?? '-'; ?></span></div>
+                            <div class="col-md-4"><strong>Linkujące domeny:</strong> <span id="moz-links"><?php echo $domain['linking_domains'] ?? '-'; ?></span></div>
                         </div>
-                        <?php if (!empty($domain['linking_domains_list'])): ?>
-                        <hr>
-                        <strong>Lista linkujących domen:</strong>
-                        <ul class="mt-2">
-                            <?php foreach (explode("\n", $domain['linking_domains_list']) as $ld): ?>
-                            <li><?php echo htmlspecialchars($ld); ?></li>
-                            <?php endforeach; ?>
-                        </ul>
-                        <?php endif; ?>
+                        <div id="moz-linking-wrapper" style="<?php echo empty($domain['linking_domains_list']) ? 'display:none;' : ''; ?>">
+                            <hr>
+                            <strong>Lista linkujących domen:</strong>
+                            <ul class="mt-2" id="moz-linking-list">
+                                <?php if (!empty($domain['linking_domains_list'])): ?>
+                                    <?php foreach (explode("\n", $domain['linking_domains_list']) as $ld): ?>
+                                        <li><?php echo htmlspecialchars($ld); ?></li>
+                                    <?php endforeach; ?>
+                                <?php endif; ?>
+                            </ul>
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- add refresh button in domain details
- implement `ajax/refresh_moz.php` to update Moz metrics
- update JS to fetch new Moz metrics and update the page

## Testing
- `php -l domains/view.php`
- `php -l ajax/refresh_moz.php`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `composer install --no-interaction` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6880bd74182c8333b51f709149e17f34